### PR TITLE
Fix deployment on k8s 1.19

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 description: elasticsearch logging chart
 name: elasticsearch-fluentd-kibana
 icon: https://gitlab.com/gitlab-com/gitlab-artwork/raw/master/logo/logo-square.png
+version: 1.0

--- a/templates/kibana-deployment.yaml
+++ b/templates/kibana-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname.kibana" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 rbac:
-  enabled: false
+  enabled: true
 #--------------------------------------------------------
 kibana:
   name: kibana


### PR DESCRIPTION
Thanks for creating the helm chart.
With k8s deployed with kubeadm + helm 3.3.3 it misses the helm chart version and the k8s api has changed slightly.

Fixes #6 